### PR TITLE
Fix numpy version to what networkx==2.4 expects

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 networkx==2.4
+numpy==1.20.1
 rhasspy-asr~=0.2.0
 rhasspy-nlu~=0.3.0
 pocketsphinx==0.1.15


### PR DESCRIPTION
See https://github.com/rhasspy/rhasspy-remote-http-hermes/pull/5 for details